### PR TITLE
Dlo1 80

### DIFF
--- a/report_client/src/services/axiosService.js
+++ b/report_client/src/services/axiosService.js
@@ -1,7 +1,11 @@
 import axios from 'axios';
 import { proxy as baseURL } from '../../package.json';
 
-export const axiosService = axios.create({ baseURL });
+const axiosOptions = {
+	baseURL: process.env.NODE_ENV === 'production' ? '/' : baseURL
+};
+
+export const axiosService = axios.create(axiosOptions);
 
 /*
  * This handles the response from the server before passing it to the next

--- a/report_server/bin/utils.js
+++ b/report_server/bin/utils.js
@@ -51,7 +51,7 @@ const onListening = (server, debug) =>
 		const addr = server.address();
 		const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port;
 		debug('Listening on ' + bind);
-		console.log('Listening on ' + bind);
+		console.log(`Listening on ${bind}, DB schema: ${process.env.DB_SCHEMA}`);
 	}
 
 module.exports = {


### PR DESCRIPTION
In production, the server and the client are running on the same port, so no need to have a proxy field at all in this environment.

Now the server also prints which schema is in use, alongside the port. As for which proxy the client is using, we can easily determine this. It just won't work if it's wrong.